### PR TITLE
Added version dependency on 'aws-sdk'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'aws-sdk'
+gem 'aws-sdk', '~> 1.0'
 gem 'uuid'


### PR DESCRIPTION
This repo requires v1 of the AWS SDK for Ruby (the aws-sdk gem). With the recent update from v1 to v2, this would not work if I clone and bundle install. Adding the version dependency.
